### PR TITLE
Add c9g (Graviton5) to AWS full-run configs

### DIFF
--- a/bench-new/config/aws-full.json
+++ b/bench-new/config/aws-full.json
@@ -6,6 +6,10 @@
   },
   "aws": [
     {
+      "instance_type": "c9g.medium",
+      "alias": "c9g"
+    },
+    {
       "instance_type": "c8g.medium",
       "alias": "c8g"
     },

--- a/bench-new/config/full.json
+++ b/bench-new/config/full.json
@@ -6,6 +6,10 @@
   },
   "aws": [
     {
+      "instance_type": "c9g.medium",
+      "alias": "c9g"
+    },
+    {
       "instance_type": "c8g.medium",
       "alias": "c8g"
     },


### PR DESCRIPTION
Adds the c9g compute-optimized instance class (Graviton5, GA 2026-07-02) to the AWS full-run configs. Arch auto-detects as arm64 via the existing regex, so no infra changes. Available in the default us-east-1 region.